### PR TITLE
fix: some fixes in cloud importers

### DIFF
--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/build.gradle.kts
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/build.gradle.kts
@@ -1,20 +1,15 @@
 dependencies {
     implementation(project(":utils"))
-    testImplementation(project(":utils-test"))
-
     implementation(project(":flamingock-core"))
     implementation(project(":flamingock-core-api"))
     implementation(project(":cloud-importers:importer-common"))
-
     implementation("software.amazon.awssdk:dynamodb-enhanced:2.25.28")
 
-    testImplementation(project(":flamingock-core"))
-
-    testImplementation("software.amazon.awssdk:url-connection-client:2.24.11")
-    testImplementation("com.amazonaws:DynamoDBLocal:1.25.0")
-
+    testImplementation(project(":utils-test"))
     testImplementation("io.mongock:mongock-standalone:5.5.0")
     testImplementation("io.mongock:dynamodb-driver:5.5.0")
+    testImplementation("software.amazon.awssdk:url-connection-client:2.24.11")
+    testImplementation("com.amazonaws:DynamoDBLocal:1.25.0")
 }
 
 java {

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/dynamodb/legacy/DynamoDBLegacyAuditReader.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/dynamodb/legacy/DynamoDBLegacyAuditReader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Flamingock (https://oss.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flamingock.importer.cloud.dynamodb.legacy;
+
+import io.flamingock.core.engine.audit.writer.AuditEntry;
+import io.flamingock.importer.cloud.common.AuditReader;
+import io.flamingock.importer.cloud.common.MongockLegacyAuditEntry;
+import io.flamingock.importer.cloud.dynamodb.legacy.entities.ChangeEntryEntity;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DynamoDBLegacyAuditReader implements AuditReader {
+
+    private final DynamoDbTable<ChangeEntryEntity> changeUnitsStorage;
+
+    public DynamoDBLegacyAuditReader(DynamoDbTable<ChangeEntryEntity> changeUnitsStorage) {
+        this.changeUnitsStorage = changeUnitsStorage;
+    }
+
+    static MongockLegacyAuditEntry toMongockLegacyAuditEntry(ChangeEntryEntity changeEntryDynamoDB) {
+        return new MongockLegacyAuditEntry(
+                changeEntryDynamoDB.getExecutionId(),
+                changeEntryDynamoDB.getChangeId(),
+                changeEntryDynamoDB.getState(),
+                changeEntryDynamoDB.getType(),
+                changeEntryDynamoDB.getAuthor(),
+                Date.from(Instant.ofEpochMilli(changeEntryDynamoDB.getTimestamp())).getTime(),
+                changeEntryDynamoDB.getChangeLogClass(),
+                changeEntryDynamoDB.getChangeSetMethod(),
+                changeEntryDynamoDB.getMetadata(),
+                changeEntryDynamoDB.getExecutionMillis(),
+                changeEntryDynamoDB.getExecutionHostname(),
+                changeEntryDynamoDB.getErrorTrace(),
+                changeEntryDynamoDB.getSystemChange()
+        );
+    }
+
+    @Override
+    public List<AuditEntry> readAuditEntries() {
+        return changeUnitsStorage
+                .scan(ScanEnhancedRequest.builder()
+                        .consistentRead(true)
+                        .build()
+                )
+                .items()
+                .stream()
+                .map(DynamoDBLegacyAuditReader::toMongockLegacyAuditEntry)
+                .map(MongockLegacyAuditEntry::toAuditEntry)
+                .sorted(Comparator.comparing(AuditEntry::getCreatedAt))
+                .collect(Collectors.toList());
+    }
+}

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/dynamodb/legacy/entities/ChangeEntryEntity.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/dynamodb/legacy/entities/ChangeEntryEntity.java
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package io.flamingock.importer.cloud.dynamodb.legacy;
+package io.flamingock.importer.cloud.dynamodb.legacy.entities;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 
 @DynamoDbBean
-public class ChangeEntry {
+public class ChangeEntryEntity {
+
+    public static final String AUDIT_LOG_TABLE_NAME = "";
 
     private String changeId;
     private String rangeKey;
@@ -38,7 +40,7 @@ public class ChangeEntry {
     private String errorTrace;
     private Boolean systemChange;
 
-    public ChangeEntry() {
+    public ChangeEntryEntity() {
     }
 
     @DynamoDbPartitionKey

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/src/test/java/io/flamingock/importer/cloud/dynamodb/legacy/DynamoDBLegcayCloudImporterTest.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/src/test/java/io/flamingock/importer/cloud/dynamodb/legacy/DynamoDBLegcayCloudImporterTest.java
@@ -33,6 +33,7 @@ import io.flamingock.core.pipeline.Stage;
 import io.flamingock.importer.cloud.common.ImporterChangeUnit;
 import io.flamingock.importer.cloud.common.MongockLegacyAuditEntry;
 import io.flamingock.importer.cloud.dynamodb.legacy.changes.ACreateCollection;
+import io.flamingock.importer.cloud.dynamodb.legacy.entities.ChangeEntryEntity;
 import io.flamingock.importer.cloud.dynamodb.legacy.mongock.ClientInitializerChangeUnit;
 import io.mongock.runner.standalone.MongockStandalone;
 import org.junit.jupiter.api.*;
@@ -174,14 +175,14 @@ class DynamoDBLegcayCloudImporterTest {
                 .buildRunner()
                 .execute();
 
-        List<ChangeEntry> mongockDbState = dynamoDBUtil.getEnhancedClient().table(mongockDynamoDBDriver.getMigrationRepositoryName(), TableSchema.fromBean(ChangeEntry.class))
+        List<ChangeEntryEntity> mongockDbState = dynamoDBUtil.getEnhancedClient().table(mongockDynamoDBDriver.getMigrationRepositoryName(), TableSchema.fromBean(ChangeEntryEntity.class))
                 .scan(ScanEnhancedRequest.builder()
                         .consistentRead(true)
                         .build()
                 )
                 .items()
                 .stream()
-                .sorted(Comparator.comparing(ChangeEntry::getTimestamp))
+                .sorted(Comparator.comparing(ChangeEntryEntity::getTimestamp))
                 .collect(Collectors.toList());
 
         //Check if Mongock works properly
@@ -194,7 +195,7 @@ class DynamoDBLegcayCloudImporterTest {
         //Prepare expectations for Mocked Server
         List<AuditEntry> importExpectations = mongockDbState
                 .stream()
-                .map(DynamoDBLegacyImportConfiguration::toMongockLegacyAuditEntry)
+                .map(DynamoDBLegacyAuditReader::toMongockLegacyAuditEntry)
                 .map(MongockLegacyAuditEntry::toAuditEntry)
                 .collect(Collectors.toList());
 
@@ -214,7 +215,7 @@ class DynamoDBLegcayCloudImporterTest {
                 "execution",
                 false
         ));
-        DynamoDBLegacyImporter dynamoDBLegacyImporter = new DynamoDBLegacyImporter(dynamoDBUtil.getEnhancedClient().table(mongockDynamoDBDriver.getMigrationRepositoryName(), TableSchema.fromBean(ChangeEntry.class)));
+        DynamoDBLegacyImporter dynamoDBLegacyImporter = new DynamoDBLegacyImporter(dynamoDBUtil.getEnhancedClient());
 
         //Run Mocked Server
         String executionId = "execution-1";

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/src/test/java/io/flamingock/importer/cloud/dynamodb/legacy/DynamoDBLegcayCloudImporterTest.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-legacy/src/test/java/io/flamingock/importer/cloud/dynamodb/legacy/DynamoDBLegcayCloudImporterTest.java
@@ -23,8 +23,12 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
 import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
-import io.flamingock.common.test.cloud.deprecated.AuditEntryMatcher;
-import io.flamingock.common.test.cloud.deprecated.MockRunnerServerOld;
+import io.flamingock.common.test.cloud.AuditRequestExpectation;
+import io.flamingock.common.test.cloud.MockRunnerServer;
+import io.flamingock.common.test.cloud.execution.ExecutionContinueRequestResponseMock;
+import io.flamingock.common.test.cloud.execution.ExecutionPlanRequestResponseMock;
+import io.flamingock.common.test.cloud.prototype.PrototypeClientSubmission;
+import io.flamingock.common.test.cloud.prototype.PrototypeStage;
 import io.flamingock.commons.utils.DynamoDBUtil;
 import io.flamingock.core.configurator.standalone.FlamingockStandalone;
 import io.flamingock.core.configurator.standalone.StandaloneCloudBuilder;
@@ -75,7 +79,7 @@ class DynamoDBLegcayCloudImporterTest {
     private static AmazonDynamoDBClient amazonClient;
     private static DynamoDBUtil dynamoDBUtil;
 
-    private static MockRunnerServerOld mockRunnerServer;
+    private static MockRunnerServer mockRunnerServer;
     private static StandaloneCloudBuilder flamingockBuilder;
 
     private final Logger logger = LoggerFactory.getLogger(DynamoDBLegcayCloudImporterTest.class);
@@ -130,7 +134,7 @@ class DynamoDBLegcayCloudImporterTest {
 
         amazonClient = getAmazonDynamoDBClient();
 
-        mockRunnerServer = new MockRunnerServerOld()
+        mockRunnerServer = new MockRunnerServer()
                 .setServerPort(runnerServerPort)
                 .setOrganisationId(organisationId)
                 .setOrganisationName(organisationName)
@@ -199,35 +203,28 @@ class DynamoDBLegcayCloudImporterTest {
                 .map(MongockLegacyAuditEntry::toAuditEntry)
                 .collect(Collectors.toList());
 
-        List<AuditEntryMatcher> auditEntryExpectations = new LinkedList<>();
-        auditEntryExpectations.add(new
-                AuditEntryMatcher(
-                "importer-v1",
-                EXECUTED,
-                ImporterChangeUnit.class.getName(),
-                "execution"
-        ));
-        auditEntryExpectations.add(new
-                AuditEntryMatcher(
-                "create-table",
-                EXECUTED,
-                ACreateCollection.class.getName(),
-                "execution",
-                false
-        ));
         DynamoDBLegacyImporter dynamoDBLegacyImporter = new DynamoDBLegacyImporter(dynamoDBUtil.getEnhancedClient());
 
         //Run Mocked Server
         String executionId = "execution-1";
         String stageName = "stage-1";
-        List<String> stageNames = new ArrayList<>();
-        stageNames.add(dynamoDBLegacyImporter.getName());
-        stageNames.add(stageName);
+
+        PrototypeClientSubmission prototypeClientSubmission = new PrototypeClientSubmission(
+                new PrototypeStage("importer", 0)
+                        .addTask("importer-v1", ImporterChangeUnit.class.getName(), "execution", true),
+                new PrototypeStage(stageName, 1)
+                        .addTask("create-table", ACreateCollection.class.getName(), "execution", false)
+        );
+
         mockRunnerServer
-                .addSuccessfulImporterCall(importExpectations)
-                .addMultipleStageExecutionPlan(executionId, stageNames, auditEntryExpectations)
-                .addExecutionWithAllTasksRequestResponse(executionId)
-                .addExecutionContinueRequestResponse()
+                .withClientSubmissionBase(prototypeClientSubmission)
+                .withExecutionPlanRequestsExpectation(
+                        new ExecutionPlanRequestResponseMock(executionId),
+                        new ExecutionContinueRequestResponseMock()
+                ).withAuditRequestsExpectation(
+                        new AuditRequestExpectation(executionId, "importer-v1", EXECUTED),
+                        new AuditRequestExpectation(executionId, "create-table", EXECUTED)
+                ).addSuccessfulImporterCall(importExpectations)
                 .start();
 
         //Finally run Flamingock changes with Cloud Importer

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-local/build.gradle.kts
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-local/build.gradle.kts
@@ -1,17 +1,14 @@
 dependencies {
     implementation(project(":utils"))
-    testImplementation(project(":utils-test"))
-
     implementation(project(":flamingock-core"))
     implementation(project(":flamingock-core-api"))
     implementation(project(":cloud-importers:importer-common"))
-
     implementation("software.amazon.awssdk:dynamodb-enhanced:2.25.28")
 
+    testImplementation(project(":utils-test"))
+    testImplementation(project(":local-drivers:dynamodb:dynamodb-driver"))
     testImplementation("software.amazon.awssdk:url-connection-client:2.24.11")
     testImplementation("com.amazonaws:DynamoDBLocal:1.25.0")
-
-    implementation(project(":local-drivers:dynamodb:dynamodb-driver"))
 }
 
 java {

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/main/java/io/flamingock/importer/cloud/dynamodb/local/DynamoDBLocalAuditReader.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/main/java/io/flamingock/importer/cloud/dynamodb/local/DynamoDBLocalAuditReader.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Flamingock (https://oss.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flamingock.importer.cloud.dynamodb.local;
+
+import io.flamingock.core.engine.audit.writer.AuditEntry;
+import io.flamingock.importer.cloud.common.AuditReader;
+import io.flamingock.importer.cloud.dynamodb.local.entities.AuditEntryEntity;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DynamoDBLocalAuditReader implements AuditReader {
+
+    private final DynamoDbTable<AuditEntryEntity> changeUnitsStorage;
+
+    public DynamoDBLocalAuditReader(DynamoDbTable<AuditEntryEntity> changeUnitsStorage) {
+        this.changeUnitsStorage = changeUnitsStorage;
+    }
+
+    @Override
+    public List<AuditEntry> readAuditEntries() {
+        return changeUnitsStorage
+                .scan(ScanEnhancedRequest.builder()
+                        .consistentRead(true)
+                        .build()
+                )
+                .items()
+                .stream()
+                .map(AuditEntryEntity::toAuditEntry)
+                .sorted(Comparator.comparing(AuditEntry::getCreatedAt))
+                .collect(Collectors.toList());
+    }
+}

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/main/java/io/flamingock/importer/cloud/dynamodb/local/DynamoDBLocalImportConfiguration.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/main/java/io/flamingock/importer/cloud/dynamodb/local/DynamoDBLocalImportConfiguration.java
@@ -18,19 +18,10 @@ package io.flamingock.importer.cloud.dynamodb.local;
 
 import io.flamingock.commons.utils.id.EnvironmentId;
 import io.flamingock.commons.utils.id.ServiceId;
-import io.flamingock.core.engine.audit.writer.AuditEntry;
 import io.flamingock.importer.cloud.common.ImporterConfiguration;
-import io.flamingock.oss.driver.dynamodb.internal.entities.AuditEntryEntity;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
-
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class DynamoDBLocalImportConfiguration implements ImporterConfiguration {
 
-    private final DynamoDbTable<AuditEntryEntity> changeUnitsStorage;
     private final EnvironmentId environmentId;
     private final String jwt;
     private final ServiceId serviceId;
@@ -39,13 +30,11 @@ public class DynamoDBLocalImportConfiguration implements ImporterConfiguration {
     public DynamoDBLocalImportConfiguration(EnvironmentId environmentId,
                                             ServiceId serviceId,
                                             String jwt,
-                                            String serverHost,
-                                            DynamoDbTable<AuditEntryEntity> changeUnitsStorage) {
+                                            String serverHost) {
         this.environmentId = environmentId;
         this.serviceId = serviceId;
         this.jwt = jwt;
         this.serverHost = serverHost;
-        this.changeUnitsStorage = changeUnitsStorage;
     }
 
     @Override
@@ -66,19 +55,5 @@ public class DynamoDBLocalImportConfiguration implements ImporterConfiguration {
     @Override
     public String getServerHost() {
         return serverHost;
-    }
-
-    @Override
-    public List<AuditEntry> readAuditEntries() {
-        return changeUnitsStorage
-                .scan(ScanEnhancedRequest.builder()
-                        .consistentRead(true)
-                        .build()
-                )
-                .items()
-                .stream()
-                .map(AuditEntryEntity::toAuditEntry)
-                .sorted(Comparator.comparing(AuditEntry::getCreatedAt))
-                .collect(Collectors.toList());
     }
 }

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/main/java/io/flamingock/importer/cloud/dynamodb/local/entities/AuditEntryEntity.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/main/java/io/flamingock/importer/cloud/dynamodb/local/entities/AuditEntryEntity.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2023 Flamingock (https://oss.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flamingock.importer.cloud.dynamodb.local.entities;
+
+import io.flamingock.core.engine.audit.writer.AuditEntry;
+import io.flamingock.core.local.AuditEntryField;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+
+@DynamoDbBean
+public class AuditEntryEntity {
+
+    public static final String AUDIT_LOG_TABLE_NAME = "flamingock_audit_log";
+    public static final String AUDIT_LOG_PK = "partitionKey";
+    public static final String AUDIT_LOG_STAGE_ID = "stageId";
+
+    protected Boolean systemChange;
+    private String partitionKey;
+    private String taskId;
+    private String stageId;
+    private String executionId;
+    private String author;
+    private LocalDateTime createdAt;
+    private AuditEntry.Status state;
+    private String className;
+    private String methodName;
+    private Object metadata;
+    private Long executionMillis;
+    private String executionHostname;
+    private Object errorTrace;
+    private AuditEntry.ExecutionType type;
+
+    public AuditEntryEntity(AuditEntry auditEntry) {
+        this.partitionKey = partitionKey(auditEntry.getExecutionId(), auditEntry.getTaskId(), auditEntry.getState());
+        this.taskId = auditEntry.getTaskId();
+        this.stageId = auditEntry.getStageId();
+        this.executionId = auditEntry.getExecutionId();
+        this.author = auditEntry.getAuthor();
+        this.createdAt = auditEntry.getCreatedAt();
+        this.state = auditEntry.getState();
+        this.className = auditEntry.getClassName();
+        this.methodName = auditEntry.getMethodName();
+        this.metadata = auditEntry.getMetadata();
+        this.executionMillis = auditEntry.getExecutionMillis();
+        this.executionHostname = auditEntry.getExecutionHostname();
+        this.errorTrace = auditEntry.getErrorTrace();
+        this.type = auditEntry.getType();
+        this.systemChange = auditEntry.getSystemChange();
+    }
+
+    public AuditEntryEntity() {
+    }
+
+    public static String partitionKey(String executionId, String taskId, AuditEntry.Status state) {
+        return executionId + '#' + taskId + '#' + state.name();
+    }
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(AUDIT_LOG_PK)
+    public String getPartitionKey() {
+        return partitionKey;
+    }
+
+    public void setPartitionKey(String partitionKey) {
+        this.partitionKey = partitionKey;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_CHANGE_ID)
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    @DynamoDbAttribute(AUDIT_LOG_STAGE_ID)
+    public String getStageId() {
+        return stageId;
+    }
+
+    public void setStageId(String stageId) {
+        this.stageId = stageId;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_EXECUTION_ID)
+    public String getExecutionId() {
+        return executionId;
+    }
+
+    public void setExecutionId(String executionId) {
+        this.executionId = executionId;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_AUTHOR)
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_TIMESTAMP)
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_STATE)
+    public String getState() {
+        return state.name();
+    }
+
+    public void setState(String state) {
+        this.state = AuditEntry.Status.valueOf(state);
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_CHANGELOG_CLASS)
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_CHANGESET_METHOD)
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_METADATA)
+    public String getMetadata() {
+        return metadata.toString();
+    }
+
+    public void setMetadata(Object metadata) {
+        this.metadata = metadata;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_EXECUTION_MILLIS)
+    public Long getExecutionMillis() {
+        return executionMillis;
+    }
+
+    public void setExecutionMillis(Long executionMillis) {
+        this.executionMillis = executionMillis;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_EXECUTION_HOSTNAME)
+    public String getExecutionHostname() {
+        return executionHostname;
+    }
+
+    public void setExecutionHostname(String executionHostname) {
+        this.executionHostname = executionHostname;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_ERROR_TRACE)
+    public String getErrorTrace() {
+        return errorTrace.toString();
+    }
+
+    public void setErrorTrace(Object errorTrace) {
+        this.errorTrace = errorTrace;
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_TYPE)
+    public String getType() {
+        return type.name();
+    }
+
+    public void setType(String type) {
+        this.type = AuditEntry.ExecutionType.valueOf(type);
+    }
+
+    @DynamoDbAttribute(AuditEntryField.KEY_SYSTEM_CHANGE)
+    public Boolean getSystemChange() {
+        return systemChange;
+    }
+
+    public void setSystemChange(Boolean systemChange) {
+        this.systemChange = systemChange;
+    }
+
+    public AuditEntry toAuditEntry() {
+        return new AuditEntry(
+                executionId,
+                stageId,
+                taskId,
+                author,
+                createdAt,
+                state,
+                type,
+                className,
+                methodName,
+                executionMillis,
+                executionHostname,
+                metadata,
+                systemChange,
+                Objects.toString(errorTrace, "")
+        );
+    }
+}

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/test/java/io/flamingock/importer/cloud/dynamodb/local/DynamoDBLocalCloudImporterTest.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/test/java/io/flamingock/importer/cloud/dynamodb/local/DynamoDBLocalCloudImporterTest.java
@@ -16,15 +16,14 @@
 
 package io.flamingock.importer.cloud.dynamodb.local;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
 import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
-import io.flamingock.common.test.cloud.deprecated.AuditEntryMatcher;
-import io.flamingock.common.test.cloud.deprecated.MockRunnerServerOld;
+import io.flamingock.common.test.cloud.AuditRequestExpectation;
+import io.flamingock.common.test.cloud.MockRunnerServer;
+import io.flamingock.common.test.cloud.execution.ExecutionContinueRequestResponseMock;
+import io.flamingock.common.test.cloud.execution.ExecutionPlanRequestResponseMock;
+import io.flamingock.common.test.cloud.prototype.PrototypeClientSubmission;
+import io.flamingock.common.test.cloud.prototype.PrototypeStage;
 import io.flamingock.commons.utils.DynamoDBUtil;
 import io.flamingock.core.configurator.standalone.FlamingockStandalone;
 import io.flamingock.core.configurator.standalone.StandaloneCloudBuilder;
@@ -71,10 +70,9 @@ class DynamoDBLocalCloudImporterTest {
 
     private static DynamoDBProxyServer dynamoDBLocal;
     private static DynamoDbClient client;
-    private static AmazonDynamoDBClient amazonClient;
     private static DynamoDBUtil dynamoDBUtil;
 
-    private static MockRunnerServerOld mockRunnerServer;
+    private static MockRunnerServer mockRunnerServer;
     private static StandaloneCloudBuilder flamingockBuilder;
 
     private final Logger logger = LoggerFactory.getLogger(DynamoDBLocalCloudImporterTest.class);
@@ -95,22 +93,6 @@ class DynamoDBLocalCloudImporterTest {
         }
     }
 
-    private static AmazonDynamoDBClient getAmazonDynamoDBClient() {
-        return (AmazonDynamoDBClient) AmazonDynamoDBClientBuilder
-                .standard()
-                .withEndpointConfiguration(
-                        new AwsClientBuilder.EndpointConfiguration(
-                                "http://localhost:8000", Region.EU_WEST_1.toString()
-                        )
-                )
-                .withCredentials(
-                        new AWSStaticCredentialsProvider(
-                                new BasicAWSCredentials("dummye", "dummye")
-                        )
-                )
-                .build();
-    }
-
     @BeforeEach
     void beforeEach() throws Exception {
         logger.info("Starting DynamoDB Local...");
@@ -127,9 +109,7 @@ class DynamoDBLocalCloudImporterTest {
 
         dynamoDBUtil = new DynamoDBUtil(client);
 
-        amazonClient = getAmazonDynamoDBClient();
-
-        mockRunnerServer = new MockRunnerServerOld()
+        mockRunnerServer = new MockRunnerServer()
                 .setServerPort(runnerServerPort)
                 .setOrganisationId(organisationId)
                 .setOrganisationName(organisationName)
@@ -193,34 +173,28 @@ class DynamoDBLocalCloudImporterTest {
                 .map(AuditEntryEntity::toAuditEntry)
                 .collect(Collectors.toList());
 
-        List<AuditEntryMatcher> auditEntryExpectations = new LinkedList<>();
-        auditEntryExpectations.add(new
-                AuditEntryMatcher(
-                "importer-v1",
-                EXECUTED,
-                ImporterChangeUnit.class.getName(),
-                "execution"
-        ));
-        auditEntryExpectations.add(new
-                AuditEntryMatcher(
-                "insert-row",
-                EXECUTED,
-                InsertClient.class.getName(),
-                "execution"
-        ));
         DynamoDBLocalImporter dynamoDBLegacyImporter = new DynamoDBLocalImporter(dynamoDBUtil.getEnhancedClient());
 
         //Run Mocked Server
         String executionId = "execution-1";
         String stageName = "stage-1";
-        List<String> stageNames = new ArrayList<>();
-        stageNames.add(dynamoDBLegacyImporter.getName());
-        stageNames.add(stageName);
+
+        PrototypeClientSubmission prototypeClientSubmission = new PrototypeClientSubmission(
+                new PrototypeStage("importer", 0)
+                        .addTask("importer-v1", ImporterChangeUnit.class.getName(), "execution", true),
+                new PrototypeStage(stageName, 1)
+                        .addTask("insert-row", InsertClient.class.getName(), "execution", true)
+        );
+
         mockRunnerServer
-                .addSuccessfulImporterCall(importExpectations)
-                .addMultipleStageExecutionPlan(executionId, stageNames, auditEntryExpectations)
-                .addExecutionWithAllTasksRequestResponse(executionId)
-                .addExecutionContinueRequestResponse()
+                .withClientSubmissionBase(prototypeClientSubmission)
+                .withExecutionPlanRequestsExpectation(
+                        new ExecutionPlanRequestResponseMock(executionId),
+                        new ExecutionContinueRequestResponseMock()
+                ).withAuditRequestsExpectation(
+                        new AuditRequestExpectation(executionId, "importer-v1", EXECUTED),
+                        new AuditRequestExpectation(executionId, "insert-row", EXECUTED)
+                ).addSuccessfulImporterCall(importExpectations)
                 .start();
 
         //Finally run Flamingock changes with Cloud Importer

--- a/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/test/java/io/flamingock/importer/cloud/dynamodb/local/DynamoDBLocalCloudImporterTest.java
+++ b/cloud-importers/dynamodb/dynamodb-cloud-importer-local/src/test/java/io/flamingock/importer/cloud/dynamodb/local/DynamoDBLocalCloudImporterTest.java
@@ -208,7 +208,7 @@ class DynamoDBLocalCloudImporterTest {
                 InsertClient.class.getName(),
                 "execution"
         ));
-        DynamoDBLocalImporter dynamoDBLegacyImporter = new DynamoDBLocalImporter(dynamoDBUtil.getEnhancedClient().table(DynamoDBConstants.AUDIT_LOG_TABLE_NAME, TableSchema.fromBean(AuditEntryEntity.class)));
+        DynamoDBLocalImporter dynamoDBLegacyImporter = new DynamoDBLocalImporter(dynamoDBUtil.getEnhancedClient());
 
         //Run Mocked Server
         String executionId = "execution-1";

--- a/cloud-importers/importer-common/src/main/java/io/flamingock/importer/cloud/common/AuditReader.java
+++ b/cloud-importers/importer-common/src/main/java/io/flamingock/importer/cloud/common/AuditReader.java
@@ -16,37 +16,12 @@
 
 package io.flamingock.importer.cloud.common;
 
-import io.flamingock.core.api.CloudSystemModule;
+import io.flamingock.core.engine.audit.writer.AuditEntry;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
+public interface AuditReader {
 
-public interface Importer extends CloudSystemModule {
-    List<Class<?>> TASK_CLASSES = Collections.singletonList(
-            ImporterChangeUnit.class
-    );
+    List<AuditEntry> readAuditEntries();
 
-    public final static String DEFAULT_MONGOCK_REPOSITORY_NAME = "mongockChangeLog";
-
-    @Override
-    default int getOrder() {
-        return 0;
-    }
-
-    @Override
-    default String getName() {
-        return "importer";
-    }
-
-    @Override
-    default Collection<Class<?>> getTaskClasses() {
-        return TASK_CLASSES;
-    }
-
-    @Override
-    default boolean isBeforeUserStages() {
-        return true;
-    }
 }

--- a/cloud-importers/importer-common/src/main/java/io/flamingock/importer/cloud/common/ImporterChangeUnit.java
+++ b/cloud-importers/importer-common/src/main/java/io/flamingock/importer/cloud/common/ImporterChangeUnit.java
@@ -33,9 +33,9 @@ public class ImporterChangeUnit {
     private static final Logger logger = LoggerFactory.getLogger(ImporterChangeUnit.class);
 
     @Execution
-    public void execution(@NonLockGuarded ImporterConfiguration configuration) {
+    public void execution(@NonLockGuarded ImporterConfiguration configuration, @NonLockGuarded AuditReader auditReader) {
 
-        List<AuditEntry> data = configuration.readAuditEntries();
+        List<AuditEntry> data = auditReader.readAuditEntries();
 
         ImporterService importerService = new ImporterService(
                 configuration.getServerHost(),

--- a/cloud-importers/importer-common/src/main/java/io/flamingock/importer/cloud/common/ImporterConfiguration.java
+++ b/cloud-importers/importer-common/src/main/java/io/flamingock/importer/cloud/common/ImporterConfiguration.java
@@ -18,9 +18,6 @@ package io.flamingock.importer.cloud.common;
 
 import io.flamingock.commons.utils.id.EnvironmentId;
 import io.flamingock.commons.utils.id.ServiceId;
-import io.flamingock.core.engine.audit.writer.AuditEntry;
-
-import java.util.List;
 
 public interface ImporterConfiguration {
 
@@ -31,7 +28,5 @@ public interface ImporterConfiguration {
     String getJwt();
 
     String getServerHost();
-
-    List<AuditEntry> readAuditEntries();
 
 }

--- a/cloud-importers/importer-common/src/main/java/io/flamingock/importer/cloud/common/MongockLegacyAuditEntry.java
+++ b/cloud-importers/importer-common/src/main/java/io/flamingock/importer/cloud/common/MongockLegacyAuditEntry.java
@@ -122,7 +122,7 @@ public class MongockLegacyAuditEntry {
     public AuditEntry toAuditEntry() {
         return new AuditEntry(
                 executionId,
-                null,
+                "legacy-imported",
                 changeId,
                 author,
                 Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).toLocalDateTime(),

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/build.gradle.kts
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/build.gradle.kts
@@ -1,18 +1,15 @@
 dependencies {
     implementation(project(":utils"))
-    testImplementation(project(":utils-test"))
-
     implementation(project(":flamingock-core"))
     implementation(project(":flamingock-core-api"))
     implementation(project(":cloud-importers:importer-common"))
-
     implementation("org.mongodb:mongodb-driver-sync:4.3.3")
 
-    testImplementation("org.testcontainers:mongodb:1.18.3")
-    testImplementation("org.testcontainers:junit-jupiter:1.18.3")
-
+    testImplementation(project(":utils-test"))
     testImplementation("io.mongock:mongock-standalone:5.5.0")
     testImplementation("io.mongock:mongodb-sync-v4-driver:5.5.0")
+    testImplementation("org.testcontainers:mongodb:1.18.3")
+    testImplementation("org.testcontainers:junit-jupiter:1.18.3")
 }
 
 java {

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/mongodb/v4/legacy/MongoDBLegacyAuditReader.java
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/mongodb/v4/legacy/MongoDBLegacyAuditReader.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Flamingock (https://oss.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flamingock.importer.cloud.mongodb.v4.legacy;
+
+import com.mongodb.client.MongoCollection;
+import io.flamingock.core.engine.audit.writer.AuditEntry;
+import io.flamingock.importer.cloud.common.AuditReader;
+import io.flamingock.importer.cloud.common.MongockLegacyAuditEntry;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MongoDBLegacyAuditReader implements AuditReader {
+
+    private final MongoCollection<Document> changeUnitsStorage;
+
+    public MongoDBLegacyAuditReader(MongoCollection<Document> changeUnitsStorage) {
+        this.changeUnitsStorage = changeUnitsStorage;
+    }
+
+    static MongockLegacyAuditEntry toMongockLegacyAuditEntry(Document document) {
+        return new MongockLegacyAuditEntry(
+                document.getString("executionId"),
+                document.getString("changeId"),
+                document.getString("state"),
+                document.getString("type"),
+                document.getString("author"),
+                document.getDate("timestamp").getTime(),
+                document.getString("changeLogClass"),
+                document.getString("changeSetMethod"),
+                document.get("metadata"),
+                document.getLong("executionMillis"),
+                document.getString("executionHostName"),
+                document.getString("errorTrace"),
+                document.getBoolean("systemChange")
+        );
+    }
+
+    @Override
+    public List<AuditEntry> readAuditEntries() {
+        return changeUnitsStorage
+                .find()
+                .into(new ArrayList<>())
+                .stream()
+                .map(MongoDBLegacyAuditReader::toMongockLegacyAuditEntry)
+                .map(MongockLegacyAuditEntry::toAuditEntry)
+                .sorted(Comparator.comparing(AuditEntry::getCreatedAt))
+                .collect(Collectors.toList());
+    }
+}

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/mongodb/v4/legacy/MongoDBLegacyImportConfiguration.java
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/mongodb/v4/legacy/MongoDBLegacyImportConfiguration.java
@@ -16,22 +16,12 @@
 
 package io.flamingock.importer.cloud.mongodb.v4.legacy;
 
-import com.mongodb.client.MongoCollection;
 import io.flamingock.commons.utils.id.EnvironmentId;
 import io.flamingock.commons.utils.id.ServiceId;
-import io.flamingock.core.engine.audit.writer.AuditEntry;
 import io.flamingock.importer.cloud.common.ImporterConfiguration;
-import io.flamingock.importer.cloud.common.MongockLegacyAuditEntry;
-import org.bson.Document;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class MongoDBLegacyImportConfiguration implements ImporterConfiguration {
 
-    private final MongoCollection<Document> changeUnitsStorage;
     private final EnvironmentId environmentId;
     private final String jwt;
     private final ServiceId serviceId;
@@ -40,31 +30,11 @@ public class MongoDBLegacyImportConfiguration implements ImporterConfiguration {
     public MongoDBLegacyImportConfiguration(EnvironmentId environmentId,
                                             ServiceId serviceId,
                                             String jwt,
-                                            String serverHost,
-                                            MongoCollection<Document> changeUnitsStorage) {
+                                            String serverHost) {
         this.environmentId = environmentId;
         this.serviceId = serviceId;
         this.jwt = jwt;
         this.serverHost = serverHost;
-        this.changeUnitsStorage = changeUnitsStorage;
-    }
-
-    static MongockLegacyAuditEntry toMongockLegacyAuditEntry(Document document) {
-        return new MongockLegacyAuditEntry(
-                document.getString("executionId"),
-                document.getString("changeId"),
-                document.getString("state"),
-                document.getString("type"),
-                document.getString("author"),
-                document.getDate("timestamp").getTime(),
-                document.getString("changeLogClass"),
-                document.getString("changeSetMethod"),
-                document.get("metadata"),
-                document.getLong("executionMillis"),
-                document.getString("executionHostName"),
-                document.getString("errorTrace"),
-                document.getBoolean("systemChange")
-        );
     }
 
     @Override
@@ -85,17 +55,5 @@ public class MongoDBLegacyImportConfiguration implements ImporterConfiguration {
     @Override
     public String getServerHost() {
         return serverHost;
-    }
-
-    @Override
-    public List<AuditEntry> readAuditEntries() {
-        return changeUnitsStorage
-                .find()
-                .into(new ArrayList<>())
-                .stream()
-                .map(MongoDBLegacyImportConfiguration::toMongockLegacyAuditEntry)
-                .map(MongockLegacyAuditEntry::toAuditEntry)
-                .sorted(Comparator.comparing(AuditEntry::getCreatedAt))
-                .collect(Collectors.toList());
     }
 }

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/mongodb/v4/legacy/MongoDBLegacyImporter.java
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/src/main/java/io/flamingock/importer/cloud/mongodb/v4/legacy/MongoDBLegacyImporter.java
@@ -16,6 +16,7 @@
 
 package io.flamingock.importer.cloud.mongodb.v4.legacy;
 
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import io.flamingock.commons.utils.id.EnvironmentId;
 import io.flamingock.commons.utils.id.ServiceId;
@@ -23,26 +24,38 @@ import io.flamingock.core.runtime.dependency.Dependency;
 import io.flamingock.importer.cloud.common.Importer;
 import org.bson.Document;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 
 public class MongoDBLegacyImporter implements Importer {
+
     private final MongoCollection<Document> changeUnitsCollection;
     private List<Dependency> dependencies;
 
-    public MongoDBLegacyImporter(MongoCollection<Document> changeUnitsCollection) {
-        this.changeUnitsCollection = changeUnitsCollection;
+    public MongoDBLegacyImporter(MongoClient mongoClient, String dbName) {
+        this.changeUnitsCollection = mongoClient.getDatabase(dbName).getCollection(DEFAULT_MONGOCK_REPOSITORY_NAME);
+    }
+
+    public MongoDBLegacyImporter(MongoClient mongoClient, String dbName, String overridenChangelogCollection) {
+        this.changeUnitsCollection = mongoClient.getDatabase(dbName).getCollection(overridenChangelogCollection);
     }
 
     @Override
     public void initialise(EnvironmentId environmentId, ServiceId serviceId, String jwt, String serverHost) {
-        dependencies = Collections.singletonList(
+        dependencies = new ArrayList<>();
+        dependencies.add(
                 new Dependency(
                         MongoDBLegacyImportConfiguration.class,
                         new MongoDBLegacyImportConfiguration(
-                                environmentId, serviceId, jwt, serverHost, changeUnitsCollection
+                                environmentId, serviceId, jwt, serverHost
                         )
+                )
+        );
+        dependencies.add(
+                new Dependency(
+                        MongoDBLegacyAuditReader.class,
+                        new MongoDBLegacyAuditReader(changeUnitsCollection)
                 )
         );
     }

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/src/test/java/io/flamingock/importer/cloud/mongodb/v4/legacy/MongoSync4LegacyCloudImporterTest.java
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-legacy/src/test/java/io/flamingock/importer/cloud/mongodb/v4/legacy/MongoSync4LegacyCloudImporterTest.java
@@ -154,7 +154,7 @@ class MongoSync4LegacyCloudImporterTest {
         //Prepare expectations for Mocked Server
         List<AuditEntry> importExpectations = mongockDbState
                 .stream()
-                .map(MongoDBLegacyImportConfiguration::toMongockLegacyAuditEntry)
+                .map(MongoDBLegacyAuditReader::toMongockLegacyAuditEntry)
                 .map(MongockLegacyAuditEntry::toAuditEntry)
                 .collect(Collectors.toList());
 
@@ -174,7 +174,7 @@ class MongoSync4LegacyCloudImporterTest {
                 "execution",
                 false
         ));
-        MongoDBLegacyImporter mongoDBLegacyImporter = new MongoDBLegacyImporter(testDatabase.getCollection(mongockMongoSync4Driver.getMigrationRepositoryName()));
+        MongoDBLegacyImporter mongoDBLegacyImporter = new MongoDBLegacyImporter(mongoClient, DB_NAME);
 
         //Run Mocked Server
         String executionId = "execution-1";

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-local/build.gradle.kts
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-local/build.gradle.kts
@@ -1,17 +1,14 @@
 dependencies {
     implementation(project(":utils"))
-    testImplementation(project(":utils-test"))
-
     implementation(project(":flamingock-core"))
     implementation(project(":flamingock-core-api"))
     implementation(project(":cloud-importers:importer-common"))
-
     implementation("org.mongodb:mongodb-driver-sync:4.3.3")
 
+    testImplementation(project(":utils-test"))
+    testImplementation(project(":local-drivers:mongodb:mongodb-sync-v4-driver"))
     testImplementation("org.testcontainers:mongodb:1.18.3")
     testImplementation("org.testcontainers:junit-jupiter:1.18.3")
-
-    testImplementation(project(":local-drivers:mongodb:mongodb-sync-v4-driver"))
 }
 
 java {

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-local/src/main/java/io/flamingock/importer/cloud/mongodb/v4/local/MongoDBLocalAuditReader.java
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-local/src/main/java/io/flamingock/importer/cloud/mongodb/v4/local/MongoDBLocalAuditReader.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Flamingock (https://oss.flamingock.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flamingock.importer.cloud.mongodb.v4.local;
+
+import com.mongodb.client.MongoCollection;
+import io.flamingock.commons.utils.TimeUtil;
+import io.flamingock.core.engine.audit.writer.AuditEntry;
+import io.flamingock.importer.cloud.common.AuditReader;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.flamingock.core.local.AuditEntryField.*;
+
+public class MongoDBLocalAuditReader implements AuditReader {
+
+    private final MongoCollection<Document> changeUnitsStorage;
+
+    public MongoDBLocalAuditReader(MongoCollection<Document> changeUnitsStorage) {
+        this.changeUnitsStorage = changeUnitsStorage;
+    }
+
+    static AuditEntry toAuditEntry(Document document) {
+        return new AuditEntry(
+                document.getString(KEY_EXECUTION_ID),
+                null,//TODO: add stage name
+                document.getString(KEY_CHANGE_ID),
+                document.getString(KEY_AUTHOR),
+                TimeUtil.toLocalDateTime(document.get(KEY_TIMESTAMP)),
+                document.containsKey(KEY_STATE) ? AuditEntry.Status.valueOf(document.getString(KEY_STATE)) : null,
+                document.containsKey(KEY_TYPE) ? AuditEntry.ExecutionType.valueOf(document.getString(KEY_TYPE)) : null,
+                document.getString(KEY_CHANGELOG_CLASS),
+                document.getString(KEY_CHANGESET_METHOD),
+                document.containsKey(KEY_EXECUTION_MILLIS) && document.get(KEY_EXECUTION_MILLIS) != null
+                        ? ((Number) document.get(KEY_EXECUTION_MILLIS)).longValue() : -1L,
+                document.getString(KEY_EXECUTION_HOSTNAME),
+                document.get(KEY_METADATA),
+                document.getBoolean(KEY_SYSTEM_CHANGE) != null && document.getBoolean(KEY_SYSTEM_CHANGE),
+                document.getString(KEY_ERROR_TRACE)
+        );
+    }
+
+    @Override
+    public List<AuditEntry> readAuditEntries() {
+        return changeUnitsStorage
+                .find()
+                .into(new ArrayList<>())
+                .stream()
+                .map(MongoDBLocalAuditReader::toAuditEntry)
+                .sorted(Comparator.comparing(AuditEntry::getCreatedAt))
+                .collect(Collectors.toList());
+    }
+}

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-local/src/test/java/io/flamingock/importer/cloud/mongodb/v4/local/MongoSync4LocalCloudImporterTest.java
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-local/src/test/java/io/flamingock/importer/cloud/mongodb/v4/local/MongoSync4LocalCloudImporterTest.java
@@ -147,7 +147,7 @@ class MongoSync4LocalCloudImporterTest {
         //Prepare expectations for Mocked Server
         List<AuditEntry> importExpectations = flamingockDbState
                 .stream()
-                .map(MongoDBLocalImportConfiguration::toAuditEntry)
+                .map(MongoDBLocalAuditReader::toAuditEntry)
                 .collect(Collectors.toList());
 
         List<AuditEntryMatcher> auditEntryExpectations = new LinkedList<>();
@@ -165,7 +165,7 @@ class MongoSync4LocalCloudImporterTest {
                 InsertClient.class.getName(),
                 "execution"
         ));
-        MongoDBLocalImporter mongoDBLegacyImporter = new MongoDBLocalImporter(testDatabase.getCollection(MongoDBSync4Configuration.DEFAULT_MIGRATION_REPOSITORY_NAME));
+        MongoDBLocalImporter mongoDBLegacyImporter = new MongoDBLocalImporter(mongoClient, DB_NAME);
 
         //Run Mocked Server
         String executionId = "execution-1";

--- a/cloud-importers/mongodb/mongodb-sync4-cloud-importer-local/src/test/java/io/flamingock/importer/cloud/mongodb/v4/local/MongoSync4LocalCloudImporterTest.java
+++ b/cloud-importers/mongodb/mongodb-sync4-cloud-importer-local/src/test/java/io/flamingock/importer/cloud/mongodb/v4/local/MongoSync4LocalCloudImporterTest.java
@@ -22,8 +22,12 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import io.flamingock.cloud.transaction.mongodb.sync.v4.cofig.MongoDBSync4Configuration;
-import io.flamingock.common.test.cloud.deprecated.AuditEntryMatcher;
-import io.flamingock.common.test.cloud.deprecated.MockRunnerServerOld;
+import io.flamingock.common.test.cloud.AuditRequestExpectation;
+import io.flamingock.common.test.cloud.MockRunnerServer;
+import io.flamingock.common.test.cloud.execution.ExecutionContinueRequestResponseMock;
+import io.flamingock.common.test.cloud.execution.ExecutionPlanRequestResponseMock;
+import io.flamingock.common.test.cloud.prototype.PrototypeClientSubmission;
+import io.flamingock.common.test.cloud.prototype.PrototypeStage;
 import io.flamingock.commons.utils.TimeUtil;
 import io.flamingock.core.configurator.standalone.FlamingockStandalone;
 import io.flamingock.core.configurator.standalone.StandaloneCloudBuilder;
@@ -74,7 +78,7 @@ class MongoSync4LocalCloudImporterTest {
     private static MongoClient mongoClient;
     private static MongoDatabase testDatabase;
 
-    private static MockRunnerServerOld mockRunnerServer;
+    private MockRunnerServer mockRunnerServer;
     private static StandaloneCloudBuilder flamingockBuilder;
 
     private final Logger logger = LoggerFactory.getLogger(MongoSync4LocalCloudImporterTest.class);
@@ -91,7 +95,7 @@ class MongoSync4LocalCloudImporterTest {
     @BeforeEach
     void beforeEach() {
 
-        mockRunnerServer = new MockRunnerServerOld()
+        mockRunnerServer = new MockRunnerServer()
                 .setServerPort(runnerServerPort)
                 .setOrganisationId(organisationId)
                 .setOrganisationName(organisationName)
@@ -150,34 +154,28 @@ class MongoSync4LocalCloudImporterTest {
                 .map(MongoDBLocalAuditReader::toAuditEntry)
                 .collect(Collectors.toList());
 
-        List<AuditEntryMatcher> auditEntryExpectations = new LinkedList<>();
-        auditEntryExpectations.add(new
-                AuditEntryMatcher(
-                "importer-v1",
-                EXECUTED,
-                ImporterChangeUnit.class.getName(),
-                "execution"
-        ));
-        auditEntryExpectations.add(new
-                AuditEntryMatcher(
-                "insert-document",
-                EXECUTED,
-                InsertClient.class.getName(),
-                "execution"
-        ));
         MongoDBLocalImporter mongoDBLegacyImporter = new MongoDBLocalImporter(mongoClient, DB_NAME);
 
         //Run Mocked Server
         String executionId = "execution-1";
         String stageName = "stage-1";
-        List<String> stageNames = new ArrayList<>();
-        stageNames.add(mongoDBLegacyImporter.getName());
-        stageNames.add(stageName);
+
+        PrototypeClientSubmission prototypeClientSubmission = new PrototypeClientSubmission(
+                new PrototypeStage("importer", 0)
+                        .addTask("importer-v1", ImporterChangeUnit.class.getName(), "execution", true),
+                new PrototypeStage(stageName, 1)
+                        .addTask("insert-document", InsertClient.class.getName(), "execution", true)
+        );
+
         mockRunnerServer
-                .addSuccessfulImporterCall(importExpectations)
-                .addMultipleStageExecutionPlan(executionId, stageNames, auditEntryExpectations)
-                .addExecutionWithAllTasksRequestResponse(executionId)
-                .addExecutionContinueRequestResponse()
+                .withClientSubmissionBase(prototypeClientSubmission)
+                .withExecutionPlanRequestsExpectation(
+                        new ExecutionPlanRequestResponseMock(executionId),
+                        new ExecutionContinueRequestResponseMock()
+                ).withAuditRequestsExpectation(
+                        new AuditRequestExpectation(executionId, "importer-v1", EXECUTED),
+                        new AuditRequestExpectation(executionId, "insert-document", EXECUTED)
+                ).addSuccessfulImporterCall(importExpectations)
                 .start();
 
         //Finally run Flamingock changes with Cloud Importer


### PR DESCRIPTION
- parameters from importers change from collection or table to client, db_name (if neccessary) and table or collection name (optional)
- configuration splits its reader function to a new AuditReader class
- set stageId to "legacy-imported" to legacy audits